### PR TITLE
Fixes #119 - removes base64 images from dcc

### DIFF
--- a/convert/developerdotchrome.py
+++ b/convert/developerdotchrome.py
@@ -38,6 +38,7 @@ class DeveloperDotChromeImporter(BaseImporter):
         # print(markdownText)
 
         markdownText = re.sub(r"{%[^%]*%}", "", markdownText)
+        markdownText = re.sub(r"<img src=\"data:image\/jpeg;[^>]+>", "", markdownText)
         text = markdownText.split("\n\n")
 
         return generate_chunks([text])


### PR DESCRIPTION
The importer crashes because the chunker can't split up base64 encoded text.... but also, we can't do anything with it anyway.