### PR TITLE
Update int to required float

### DIFF
--- a/polymath/library.py
+++ b/polymath/library.py
@@ -253,7 +253,7 @@ class Bit:
 
     @property
     def similarity(self) -> float:
-        result = self._data.get('similarity', -1.0)
+        result = self._data.get('similarity', -1)
         if not isinstance(result, float):
             raise Exception('similarity not float as expected')
         return result

--- a/polymath/library.py
+++ b/polymath/library.py
@@ -253,7 +253,7 @@ class Bit:
 
     @property
     def similarity(self) -> float:
-        result = self._data.get('similarity', -1)
+        result = self._data.get('similarity', -1.0)
         if not isinstance(result, float):
             raise Exception('similarity not float as expected')
         return result


### PR DESCRIPTION
In polymath/library.py the similarity function expected a float but the default value was an int. This change updates it to a float.